### PR TITLE
Fix: `VUE_APP_DEFAULT_USER_IMG_PATH`

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -40,7 +40,7 @@ const idTokenClaims = ref();
 
 store.dispatch(
   "setDefaultUserUri",
-  process.env.VUE_APP_ROOT_IMG + process.env.VUE_APP_DEFAULT_USER_IMG
+  process.env.VUE_APP_ROOT_IMG + process.env.VUE_APP_DEFAULT_USER_IMG_PATH
 );
 
 /**


### PR DESCRIPTION
`App.vue`のデフォルトユーザープロフィール画像のパスの環境変数が`VUE_APP_DEFAULT_USER_IMG`になっていたため、`GitHub Actions`と共通の変数名である`VUE_APP_DEFAULT_USER_IMG_PATH`に修正