### PR TITLE
Change: auth0 `cacheLocation` to `localstorage`#75

### DIFF
--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -12,6 +12,7 @@ createApp(App)
       domain: process.env.VUE_APP_AUTH0_DOMAIN,
       client_id: process.env.VUE_APP_AUTH0_CLIENT_ID,
       redirect_uri: window.location.origin,
+      cacheLocation: "localstorage",
     })
   )
   .use(store)


### PR DESCRIPTION
- #75
- MFAを有効にするとサイレント認証が使えないため認証Tokenをローカルストレージに格納する仕様に変更