### PR TITLE
Fix: `EmailIsNotVerified.vue`

### DIFF
--- a/app/src/components/parts/buttons/EmailVerifiedButton.vue
+++ b/app/src/components/parts/buttons/EmailVerifiedButton.vue
@@ -1,0 +1,7 @@
+<template>
+  <button
+    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full md:w-full lg:w-auto shadow"
+  >
+    Email Verified
+  </button>
+</template>

--- a/app/src/views/error/EmailIsNotVerified.vue
+++ b/app/src/views/error/EmailIsNotVerified.vue
@@ -44,6 +44,14 @@
             />
           </div>
         </div>
+        <div class="flex flex-row-reverse">
+          <div>
+            <label class="mr-2 text-lg text-gray-700"
+              >Have you finished verifying your Email?</label
+            >
+            <EmailVerifiedButton @click="emailVerified" />
+          </div>
+        </div>
       </div>
     </section>
   </div>
@@ -57,11 +65,13 @@ import { watch } from "vue";
 import userFetcher from "@/js/fetchers/userFetcher";
 import AlertIndicate from "@/components/parts/AlertIndicate.vue";
 import LoadingSpinner from "@/components/parts/LoadingSpinner.vue";
+import EmailVerifiedButton from "@/components/parts/buttons/EmailVerifiedButton.vue";
 
 export default {
   components: {
     AlertIndicate,
     LoadingSpinner,
+    EmailVerifiedButton,
   },
 
   setup() {
@@ -92,6 +102,15 @@ export default {
       isProcessingSendEmail.value = false;
     };
 
+    /**
+     * Email検証完了後にボタン押下でユーザー情報を再取得
+     */
+    const emailVerified = () => {
+      auth0.loginWithRedirect({
+        redirect_uri: process.env.VUE_APP_REDIRECT_URL + "login",
+      });
+    };
+
     return {
       isLoading: auth0.isLoading,
       cssSetting: setting,
@@ -99,6 +118,7 @@ export default {
       isProcessingSendEmail,
       isSuccessSendEmail,
       resendVerificationEmail,
+      emailVerified,
     };
   },
   computed: {


### PR DESCRIPTION
## 不具合内容
- ログイン処理の仕様変更により`email_verified`が正常に更新されない状態となっていた
- Emailの検証画面からリダイレクトされると正常に処理される

## 対応
- `EmailVerifiedButton` 押下で`loginWithRedirect`を発火させて認証情報を再取得させた